### PR TITLE
KMS proxy: basic metrics + degradation tests

### DIFF
--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -5,6 +5,7 @@ pub mod retry;
 pub mod limits;
 pub mod rate_limit;
 pub mod circuit_breaker;
+pub mod metrics;
 pub mod proxy;
 pub mod storage;
 pub mod spy;

--- a/host/src/metrics.rs
+++ b/host/src/metrics.rs
@@ -1,0 +1,83 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Minimal in-process counters for v1 operability.
+///
+/// We keep it intentionally simple (no external exporter yet):
+/// - useful for structured logs and later wiring to Prometheus/CloudWatch.
+#[derive(Clone, Debug, Default)]
+pub struct Metrics {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    pub kms_requests_total: AtomicU64,
+    pub kms_success_total: AtomicU64,
+    pub kms_errors_total: AtomicU64,
+
+    pub retries_total: AtomicU64,
+    pub throttled_total: AtomicU64,
+    pub timeouts_total: AtomicU64,
+    pub rate_limited_total: AtomicU64,
+    pub circuit_wait_total: AtomicU64,
+}
+
+impl Metrics {
+    pub fn inc_requests(&self) {
+        self.inner.kms_requests_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_success(&self) {
+        self.inner.kms_success_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_error(&self) {
+        self.inner.kms_errors_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_retry(&self) {
+        self.inner.retries_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_throttled(&self) {
+        self.inner.throttled_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_timeout(&self) {
+        self.inner.timeouts_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_rate_limited(&self) {
+        self.inner.rate_limited_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_circuit_wait(&self) {
+        self.inner.circuit_wait_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        MetricsSnapshot {
+            kms_requests_total: self.inner.kms_requests_total.load(Ordering::Relaxed),
+            kms_success_total: self.inner.kms_success_total.load(Ordering::Relaxed),
+            kms_errors_total: self.inner.kms_errors_total.load(Ordering::Relaxed),
+            retries_total: self.inner.retries_total.load(Ordering::Relaxed),
+            throttled_total: self.inner.throttled_total.load(Ordering::Relaxed),
+            timeouts_total: self.inner.timeouts_total.load(Ordering::Relaxed),
+            rate_limited_total: self.inner.rate_limited_total.load(Ordering::Relaxed),
+            circuit_wait_total: self.inner.circuit_wait_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MetricsSnapshot {
+    pub kms_requests_total: u64,
+    pub kms_success_total: u64,
+    pub kms_errors_total: u64,
+    pub retries_total: u64,
+    pub throttled_total: u64,
+    pub timeouts_total: u64,
+    pub rate_limited_total: u64,
+    pub circuit_wait_total: u64,
+}

--- a/host/tests/degradation_tests.rs
+++ b/host/tests/degradation_tests.rs
@@ -1,0 +1,44 @@
+use ephemeral_ml_host::{
+    circuit_breaker::{CircuitBreaker, Config as CircuitConfig},
+    rate_limit::{Config as RateLimitConfig, RateLimiter},
+    retry::RetryPolicy,
+};
+use std::time::Duration;
+use tokio::time::Instant;
+
+#[tokio::test]
+async fn degradation_rate_limiter_throttles() {
+    let rl = RateLimiter::new(RateLimitConfig { rps: 5.0, burst: 1.0 });
+
+    assert!(!rl.acquire(1.0).await);
+    let t0 = Instant::now();
+    assert!(rl.acquire(1.0).await);
+    assert!(t0.elapsed() >= Duration::from_millis(150));
+}
+
+#[tokio::test]
+async fn degradation_circuit_breaker_opens() {
+    let cb = CircuitBreaker::new(CircuitConfig {
+        window: Duration::from_secs(60),
+        open_cooldown: Duration::from_millis(80),
+        min_requests: 5,
+        open_error_rate: 0.6,
+    });
+
+    for _ in 0..5 {
+        cb.before_request().await;
+        cb.record_result(false).await;
+    }
+
+    let t0 = Instant::now();
+    cb.before_request().await;
+    assert!(t0.elapsed() >= Duration::from_millis(60));
+}
+
+#[test]
+fn degradation_retry_policy_caps_backoff() {
+    let p = RetryPolicy::default();
+    assert_eq!(p.max_attempts, 3);
+    assert_eq!(p.backoff_base, Duration::from_millis(20));
+    assert_eq!(p.backoff_cap, Duration::from_millis(200));
+}


### PR DESCRIPTION
Adds v1 operability scaffolding:
- Minimal in-process counters (requests/success/errors/retries/throttling/timeouts/rate-limited)
- Updates rate limiter to report whether it had to wait
- Adds degradation tests for rate limiting and circuit breaker behavior

Next: wire counters into structured JSON logs and/or export via Prometheus/CloudWatch (future PR).