### PR TITLE
KMS proxy: structured JSON logs + metrics snapshot

### DIFF
--- a/host/src/kms_proxy_server.rs
+++ b/host/src/kms_proxy_server.rs
@@ -64,6 +64,10 @@ impl KmsProxyServer {
         self
     }
 
+    pub fn metrics_snapshot(&self) -> crate::metrics::MetricsSnapshot {
+        self.metrics.snapshot()
+    }
+
     pub async fn handle_envelope(&mut self, env: KmsProxyRequestEnvelope) -> KmsProxyResponseEnvelope {
         self.metrics.inc_requests();
 

--- a/host/src/metrics.rs
+++ b/host/src/metrics.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -70,7 +71,7 @@ impl Metrics {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
 pub struct MetricsSnapshot {
     pub kms_requests_total: u64,
     pub kms_success_total: u64,


### PR DESCRIPTION
Adds structured JSON logging for KMS proxy:
- Logs request (event=kms_proxy_request) with request_id/trace_id/op/recipient/ciphertext_len
- Logs response (event=kms_proxy_response) with ok/error_code/kms_request_id/duration_ms + metrics snapshot
- Exposes metrics_snapshot() from KmsProxyServer

All logs are redacted: no attestation bytes, ciphertext bytes, or plaintext bytes are printed.